### PR TITLE
inlining: copy inlinelevel with the call node (fixes upstream#41184)

### DIFF
--- a/compiler/ncal.pas
+++ b/compiler/ncal.pas
@@ -1911,6 +1911,7 @@ implementation
         n.procdefinition:=procdefinition;
         n.typedef := typedef;
         n.callnodeflags := callnodeflags;
+        n.inlinelevel := inlinelevel;
         n.pushedparasize := pushedparasize;
         n.intrinsiccode := intrinsiccode;
         if assigned(callinitblock) then

--- a/tests/webtbs/tw41184.pp
+++ b/tests/webtbs/tw41184.pp
@@ -1,0 +1,21 @@
+{ %norun }
+
+program tw41184;
+
+{$mode delphi}
+{$warn 6058 off}
+
+type
+  TMyClass = class;
+  TMyClassClass = class of TMyClass;
+  TMyClass = class
+    class function Func: TMyClassClass; inline;
+  end;
+
+class function TMyClass.Func: TMyClassClass;
+begin
+  Func().Func;
+end;
+
+begin
+end.


### PR DESCRIPTION
**Problem.** FPC issue [#41184](https://gitlab.com/freepascal.org/fpc/source/-/issues/41184): `Func().Func` inside an inline class function compiles forever. `tcallnode.dogetcopy` did not carry the transient `inlinelevel`, so a recursive inline call copied through an initialization or argument tree restarted at level 0 and bypassed the growth heuristic until the compiler ran out of stack.

**Fix.** Copy `inlinelevel` together with the rest of the call node state (one line). Non-recursive inlining is unchanged.

**Test.** `tests/webtbs/tw41184.pp` (`%norun`): compiler crash on current `main`, compiles after the fix.

**Validation.** Win64 build of `main` (a359fc19) with the patch; 405 neighbouring tests from `tests/test` (inline, rtti, helpers, generics, opt) give identical results before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)