### PR TITLE
rtti: skip generic methods in the legacy VMT method table (fixes upstream#41410)

### DIFF
--- a/compiler/ncgvmt.pas
+++ b/compiler/ncgvmt.pas
@@ -462,7 +462,8 @@ implementation
           begin
             pd:=tprocdef(Tprocsym(p).ProcdefList[i]);
             if (pd.procsym=tsym(p)) and
-               (pd.visibility=vis_published) then
+               (pd.visibility=vis_published) and
+               not pd.is_generic then
               inc(plongint(arg)^);
           end;
       end;
@@ -490,7 +491,8 @@ implementation
           begin
             pd:=tprocdef(Tprocsym(p).ProcdefList[i]);
             if (pd.procsym=tsym(p)) and
-               (pd.visibility=vis_published) then
+               (pd.visibility=vis_published) and
+               not pd.is_generic then
               begin
                 { l: name_of_method }
                 lists^.pubmethodstcb.start_internal_data_builder(current_asmdata.AsmLists[al_const],sec_rodata,_class.vmt_mangledname,datatcb,l);

--- a/tests/webtbs/tw41410.pp
+++ b/tests/webtbs/tw41410.pp
@@ -1,0 +1,44 @@
+program tw41410;
+
+{$mode delphi}
+
+type
+  {$M+}
+  TContainer = class
+  private
+    FValue: Integer;
+  published
+    procedure Ping;
+    procedure Test<T>(const AValue: T);
+  end;
+  {$M-}
+
+procedure TContainer.Ping;
+begin
+  FValue := 7;
+end;
+
+procedure TContainer.Test<T>(const AValue: T);
+begin
+  FValue := SizeOf(AValue);
+end;
+
+var
+  Container: TContainer;
+begin
+  Container := TContainer.Create;
+  try
+    if Container.MethodAddress('Ping') = nil then
+      Halt(1);
+    if Container.MethodAddress('Test') <> nil then
+      Halt(2);
+    Container.Ping;
+    if Container.FValue <> 7 then
+      Halt(3);
+    Container.Test<Int64>(42);
+    if Container.FValue <> SizeOf(Int64) then
+      Halt(4);
+  finally
+    Container.Free;
+  end;
+end.


### PR DESCRIPTION
**Problem.** FPC issue [#41410](https://gitlab.com/freepascal.org/fpc/source/-/issues/41410): a published open generic method has no callable body, but the legacy method table writer counted it and emitted a reference to the generic template symbol, so a valid `{$M+}` class failed at link time with an undefined symbol.

**Fix.** Make the counting and writing predicates in `ncgvmt.pas` symmetric and exclude `tprocdef.is_generic`, as the extended RTTI writer already does. Ordinary published methods and real specializations are unaffected.

**Test.** `tests/webtbs/tw41410.pp`: link error on current `main`, runs after the fix.

**Validation.** Win64 build of `main` (a359fc19) with the patch; 405 neighbouring tests from `tests/test` (inline, rtti, helpers, generics, opt) give identical results before and after.

:robot: Generated with [Claude Code](https://claude.com/claude-code)