### PR TITLE
helpers: key distinct type aliases by their own identity (fixes upstream#41564)

### DIFF
--- a/compiler/symtable.pas
+++ b/compiler/symtable.pas
@@ -3243,7 +3243,8 @@ implementation
             assigned(tstoreddef(def).genericdef) and
             assigned(def.typesym) then
           result:=make_mangledname('',tstoreddef(def).genericdef.owner,def.typesym.name)
-        else if def.typ in [recorddef,objectdef] then
+        else if (def.typ in [recorddef,objectdef]) and
+           not (df_unique in def.defoptions) then
           result:=make_mangledname('',tabstractrecorddef(def).symtable,'')
         else
           result:=make_mangledname('',def.owner,def.typesym.name);

--- a/tests/webtbs/tw41564.pp
+++ b/tests/webtbs/tw41564.pp
@@ -1,0 +1,80 @@
+program tw41564;
+
+{$mode delphi}
+
+type
+  TBase = record
+    Value: Integer;
+  end;
+  TAlias = TBase;
+  TFirst = type TBase;
+  TSecond = type TBase;
+
+  TBaseHelper = record helper for TBase
+    function Marker: Integer;
+    class function StaticMarker: Integer; static;
+  end;
+
+  TFirstHelper = record helper for TFirst
+    function Marker: Integer;
+    class function StaticMarker: Integer; static;
+  end;
+
+  TSecondHelper = record helper for TSecond
+    function Marker: Integer;
+    class function StaticMarker: Integer; static;
+  end;
+
+function TBaseHelper.Marker: Integer;
+begin
+  Result := 10;
+end;
+
+class function TBaseHelper.StaticMarker: Integer;
+begin
+  Result := 20;
+end;
+
+function TFirstHelper.Marker: Integer;
+begin
+  Result := 11;
+end;
+
+class function TFirstHelper.StaticMarker: Integer;
+begin
+  Result := 21;
+end;
+
+function TSecondHelper.Marker: Integer;
+begin
+  Result := 12;
+end;
+
+class function TSecondHelper.StaticMarker: Integer;
+begin
+  Result := 22;
+end;
+
+var
+  Base: TBase;
+  AliasValue: TAlias;
+  First: TFirst;
+  Second: TSecond;
+begin
+  if Base.Marker <> 10 then
+    Halt(1);
+  if AliasValue.Marker <> 10 then
+    Halt(2);
+  if First.Marker <> 11 then
+    Halt(3);
+  if Second.Marker <> 12 then
+    Halt(4);
+  if TBase.StaticMarker <> 20 then
+    Halt(5);
+  if TAlias.StaticMarker <> 20 then
+    Halt(6);
+  if TFirst.StaticMarker <> 21 then
+    Halt(7);
+  if TSecond.StaticMarker <> 22 then
+    Halt(8);
+end.


### PR DESCRIPTION
**Problem.** FPC issue [#41564](https://gitlab.com/freepascal.org/fpc/source/-/issues/41564): the helper key for a record or object was built from the base structure's symbol table, so several distinct aliases of one record (`type TA = type TB`) shared a single key and lookup returned the helper registered last for any of them.

**Fix.** In `generate_objectpascal_helper_key` a `df_unique` def now keys by its own owner and name; plain aliases keep the structural key. Your helper-key refactor on `main` already routes both registration and lookup through this function, so the change is two lines.

**Test.** `tests/webtbs/tw41564.pp`: wrong helper picked on current `main`, correct after the fix.

**Validation.** Win64 build of `main` (a359fc19) with the patch; 405 neighbouring tests from `tests/test` (inline, rtti, helpers, generics, opt) give identical results before and after.

:robot: Generated with [Claude Code](https://claude.com/claude-code)