### PR TITLE
cse: drop short-circuit values before an always-evaluated right side (fixes upstream#41809)

### DIFF
--- a/compiler/optcse.pas
+++ b/compiler/optcse.pas
@@ -124,25 +124,53 @@ unit optcse;
           and  C
           / \
          A   B
-        all expressions of B are available during evaluation of C. However considerung the whole expression,
+        all expressions of B are available during evaluation of C. However considering the whole expression,
         values of B and C might not be available due to short boolean evaluation.
 
-        So recurseintobooleanchain detects such chained and/or expressions and makes sub-expressions of B
-        available during the evaluation of C
+        recurseintobooleanchain detects such chained and/or expressions. Before
+        collecting an always-evaluated right side, it removes values produced by
+        conditionally evaluated left-side branches from the available set.
 
-        firstleftend is later used to remove all sub expressions of B and C by storing the expression count
-        in the cse table after handling A
+        firstleftend stores the expression count after handling A. It bounds the
+        part of the CSE table that can contain conditionally produced values.
       }
       var
         firstleftend : longint;
+        maybeskipped : TDFASet; { Only valid for the current collectnodes invocation }
+
       procedure recurseintobooleanchain(t : tnodetype;n : tnode);
+        var
+          i,rightstart : longint;
         begin
           if (tbinarynode(n).left.nodetype=t) and is_boolean(tbinarynode(n).left.resultdef) then
             recurseintobooleanchain(t,tbinarynode(n).left)
           else
             foreachnodestatic(pm_postprocess,tbinarynode(n).left,@collectnodes2,arg);
-          firstleftend:=min(plists(arg)^.nodelist.count,firstleftend);
-          foreachnodestatic(pm_postprocess,tbinarynode(n).right,@collectnodes2,arg);
+
+          rightstart:=plists(arg)^.nodelist.count;
+          firstleftend:=min(rightstart,firstleftend);
+
+          if doshortbooleval(n) then
+            begin
+              foreachnodestatic(pm_postprocess,tbinarynode(n).right,@collectnodes2,arg);
+
+              { Short boolean evaluation can skip the right side of nested nodes. }
+              for i:=rightstart to plists(arg)^.nodelist.count-1 do
+                DynSetInclude(maybeskipped,i);
+            end
+          else
+            begin
+              { The right side is evaluated even if a nested short node skipped
+                part of the left side. Do not expose those conditional values
+                while collecting this always-evaluated right side. }
+              for i:=firstleftend to rightstart-1 do
+                if DynSetIn(maybeskipped,i) then
+                  DynSetExclude(plists(arg)^.avail,i);
+
+              { Collect only after pruning conditional values so new entries
+                cannot record references to them. }
+              foreachnodestatic(pm_postprocess,tbinarynode(n).right,@collectnodes2,arg);
+            end;
         end;
 
       var
@@ -277,12 +305,14 @@ unit optcse;
           the expressions of the right side might not be available due to short boolean
           evaluation, so after handling the right side, mark those expressions
           as unavailable }
-        if (n.nodetype in [orn,andn]) and is_boolean(taddnode(n).left.resultdef) then
+        if doshortbooleval(n) and is_boolean(taddnode(n).left.resultdef) then
           begin
+            SetLength(maybeskipped,0);
             firstleftend:=high(longint);
             recurseintobooleanchain(n.nodetype,n);
             for i:=firstleftend to plists(arg)^.nodelist.count-1 do
-              DynSetExclude(plists(arg)^.avail,i);
+              if DynSetIn(maybeskipped,i) then
+                DynSetExclude(plists(arg)^.avail,i);
             result:=fen_norecurse_false;
           end;
 {$ifdef cpuhighleveltarget}

--- a/tests/test/opt/tcseshortcutavailability1.pp
+++ b/tests/test/opt/tcseshortcutavailability1.pp
@@ -1,0 +1,157 @@
+{ %OPT=-O2 }
+
+program tcseshortcutavailability1;
+
+{$mode objfpc}
+
+type
+  TPair = record
+    A: LongInt;
+    B: LongInt;
+  end;
+  PPair = ^TPair;
+
+var
+  Gate: LongInt;
+  Pair: TPair;
+  PairPointer: PPair;
+  Events: array[0..3] of LongInt;
+
+{$B-}
+function ShortAnd: Boolean; inline;
+begin
+  Result := (Gate <> 0) and (Pair.B = 0);
+end;
+
+function ShortOr: Boolean; inline;
+begin
+  Result := (Gate = 0) or (Pair.B = 0);
+end;
+
+function ShortPointerAnd: Boolean; inline;
+begin
+  Result := (Gate <> 0) and (PairPointer^.B = 0);
+end;
+
+{$B+}
+function FullAnd: Boolean; inline;
+begin
+  Result := (Gate <> 0) and (Pair.B = 0);
+end;
+
+function FullOr: Boolean; inline;
+begin
+  Result := (Gate = 0) or (Pair.B = 0);
+end;
+
+function ExpectedAnd(D,A,B: LongInt): Boolean; noinline;
+begin
+  Result:=False;
+  if D<>0 then
+    if B=0 then
+      if A<>0 then
+        Result:=True;
+end;
+
+function ExpectedOrAnd(D,A,B: LongInt): Boolean; noinline;
+begin
+  Result:=False;
+  if D=0 then
+    begin
+      if A<>0 then
+        Result:=True;
+    end
+  else if B=0 then
+    if A<>0 then
+      Result:=True;
+end;
+
+function ExpectedAndOr(D,A,B: LongInt): Boolean; noinline;
+begin
+  Result:=False;
+  if A<>0 then
+    Result:=True
+  else if D<>0 then
+    if B=0 then
+      Result:=True;
+end;
+
+function Mark(Event: LongInt;Value: Boolean): Boolean; noinline;
+begin
+  Inc(Events[Event]);
+  Result:=Value;
+end;
+
+function ShortEvents: Boolean; inline;
+begin
+  {$B-}
+  Result:=Mark(1,False) and Mark(2,True);
+end;
+
+procedure Check(Value,Expected: Boolean;Code: LongInt); noinline;
+begin
+  if Value<>Expected then
+    Halt(Code);
+end;
+
+procedure CheckPureMatrix;
+var
+  D,A,B: LongInt;
+begin
+  PairPointer:=@Pair;
+  for D:=0 to 1 do
+    for A:=0 to 1 do
+      for B:=0 to 1 do
+        begin
+          Gate:=D;
+          Pair.A:=A;
+          Pair.B:=B;
+
+          {$B-}
+          Check(ShortAnd and (Pair.A<>0),ExpectedAnd(D,A,B),11);
+          Check(ShortOr and (Pair.A<>0),ExpectedOrAnd(D,A,B),12);
+
+          {$B+}
+          Check(ShortAnd and (Pair.A<>0),ExpectedAnd(D,A,B),13);
+          Check(ShortAnd or (Pair.A<>0),ExpectedAndOr(D,A,B),14);
+          Check(ShortOr and (Pair.A<>0),ExpectedOrAnd(D,A,B),15);
+          Check(FullAnd and (Pair.A<>0),ExpectedAnd(D,A,B),16);
+          Check(FullOr and (Pair.A<>0),ExpectedOrAnd(D,A,B),17);
+          Check(ShortPointerAnd and (PairPointer^.A<>0),ExpectedAnd(D,A,B),18);
+
+          {$B-}
+          Check(FullAnd and (Pair.A<>0),ExpectedAnd(D,A,B),19);
+          Check(FullOr and (Pair.A<>0),ExpectedOrAnd(D,A,B),20);
+        end;
+end;
+
+procedure CheckEvaluationEvents;
+var
+  Value: Boolean;
+begin
+  FillChar(Events,SizeOf(Events),0);
+  {$B-}
+  Value:=Mark(1,False) and Mark(2,True);
+  Check(Value,False,31);
+  if (Events[1]<>1) or (Events[2]<>0) then
+    Halt(32);
+
+  FillChar(Events,SizeOf(Events),0);
+  {$B+}
+  Value:=Mark(1,False) and Mark(2,True);
+  Check(Value,False,33);
+  if (Events[1]<>1) or (Events[2]<>1) then
+    Halt(34);
+
+  FillChar(Events,SizeOf(Events),0);
+  {$B+}
+  Value:=ShortEvents and Mark(3,True);
+  Check(Value,False,35);
+  if (Events[1]<>1) or (Events[2]<>0) or (Events[3]<>1) then
+    Halt(36);
+end;
+
+begin
+  CheckPureMatrix;
+  CheckEvaluationEvents;
+end.

--- a/tests/webtbs/tw41809.pp
+++ b/tests/webtbs/tw41809.pp
@@ -1,0 +1,49 @@
+{ %OPT=-O2 }
+
+{ With a short circuit and/or chain the cse pass treats expressions of
+  a right side as available in later links of the chain. That only
+  holds while the chain stays short circuit: once the outer and/or is
+  converted to full boolean evaluation (here after inlining foo, whose
+  body stays short circuit), its right side also runs when the inner
+  right side was skipped, and reusing the shared temp dereferenced a
+  register that was only set on the skipped path. }
+
+program tw41809;
+
+{$mode objfpc}
+
+var
+  gate: integer;
+  pair: record
+    a, b: integer;
+  end;
+
+function foo: boolean; inline;
+begin
+  result := (gate <> 0) and (pair.b = 0);
+end;
+
+var
+  d, a, b: integer;
+  got, want: boolean;
+begin
+  gate := ParamCount;
+  pair.a := ParamCount;
+  pair.b := ParamCount;
+  if foo and (pair.a <> 0) then
+    Halt(1);
+
+  for d := 0 to 1 do
+    for a := 0 to 1 do
+      for b := 0 to 1 do
+        begin
+          gate := d;
+          pair.a := a;
+          pair.b := b;
+          got := foo and (pair.a <> 0);
+          want := (d <> 0) and (b = 0) and (a <> 0);
+          if got <> want then
+            Halt(2);
+        end;
+  writeln('ok');
+end.

--- a/tests/webtbs/tw41809a.pp
+++ b/tests/webtbs/tw41809a.pp
@@ -1,0 +1,22 @@
+{ %OPT=-O2 -OoNODFA }
+program tw41809a;
+
+{$mode objfpc}
+
+var
+  dummy: integer;
+  rec: record
+    a, b: integer;
+  end;
+  q: integer;
+
+function kek: boolean; inline;
+begin
+  result := (dummy <> 0) and (rec.b = 0);
+end;
+
+begin
+  q := ParamCount;
+  if kek and (rec.a <> 0) and (q * q + q = 7) then;
+  WriteLn('ok');
+end.


### PR DESCRIPTION
**Problem.** FPC issue [#41809](https://gitlab.com/freepascal.org/fpc/source/-/issues/41809): in a short-circuit `and`/`or` chain the CSE pass treats the expressions of a right side as available in the later links of the chain. That only holds while the chain stays short-circuit. Once an outer `and`/`or` is evaluated with full boolean evaluation (for example after inlining a short-circuit body into it), its right side also runs when the inner right side was skipped, and reusing the shared temp reads a register that was only set on the skipped path. Pierre's reproducer from the issue crashes on current `main` at `-O2` and `-O3`.

**Fix.** In `optcse.pas` track which nodelist entries come from a short-circuited right side and remove them from the available set before collecting an always-evaluated right side. Plain short-circuit chains are handled as before.

**Tests.** `tests/webtbs/tw41809.pp` (AV on current `main`), `tests/webtbs/tw41809a.pp` (`-OoNODFA` variant) and `tests/test/opt/tcseshortcutavailability1.pp` (short and full evaluation, pointers, and/or, nested forms).

**Validation.** Win64 build of `main` (a359fc19) with the patch; 405 neighbouring tests from `tests/test` (inline, rtti, helpers, generics, opt) give identical results before and after, plus the new test. FPC has an open merge request !1509 for the same issue with a different approach; we will reference this patch there.

:robot: Generated with [Claude Code](https://claude.com/claude-code)