### PR TITLE
x86: normalize immediates when narrowing folded arithmetic (fixes upstream#41480)

### DIFF
--- a/compiler/x86/aoptx86.pas
+++ b/compiler/x86/aoptx86.pas
@@ -167,6 +167,7 @@ unit aoptx86;
 
         class function IsExitCode(p : tai) : boolean; static;
         class function isFoldableArithOp(hp1 : taicpu; reg : tregister) : boolean; static;
+        class procedure ChangeArithmeticOpSize(const p: taicpu; const NewSize: topsize); static;
         class function IsShrMovZFoldable(shr_size, movz_size: topsize; Shift: TCGInt): Boolean; static;
         procedure RemoveLastDeallocForFuncRes(p : tai);
 
@@ -2372,6 +2373,19 @@ unit aoptx86;
           else
             ;
         end;
+      end;
+
+
+    class procedure TX86AsmOptimizer.ChangeArithmeticOpSize(const p: taicpu; const NewSize: topsize);
+      var
+        NewBitSize: longint;
+      begin
+        NewBitSize:=topsize2memsize[NewSize];
+        if (topsize2memsize[p.opsize]>NewBitSize) and
+          (p.oper[0]^.typ=top_const) and
+          (NewBitSize<=63) then
+          p.oper[0]^.val:=p.oper[0]^.val and ((qword(1) shl NewBitSize)-1);
+        p.changeopsize(NewSize);
       end;
 
 
@@ -5576,7 +5590,7 @@ unit aoptx86;
                           debug_op2str(taicpu(p).opcode)+debug_opsize2str(taicpu(p).opsize)+' '+
                           debug_op2str(taicpu(hp1).opcode)+debug_opsize2str(taicpu(hp1).opsize)+' '+
                           debug_op2str(taicpu(hp2).opcode)+debug_opsize2str(taicpu(hp2).opsize)+')',p);
-                    taicpu(hp1).changeopsize(taicpu(hp2).opsize);
+                    ChangeArithmeticOpSize(taicpu(hp1),taicpu(hp2).opsize);
                     {
                       ->
                         movswl  %si,%eax        movswl  %si,%eax      p
@@ -5659,7 +5673,6 @@ unit aoptx86;
                       check opsize to avoid overflow when left shifting the 1 }
                     if (taicpu(p).oper[0]^.typ=top_const) and (topsize2memsize[taicpu(hp2).opsize]<=63) then
                       taicpu(p).oper[0]^.val:=taicpu(p).oper[0]^.val and ((qword(1) shl topsize2memsize[taicpu(hp2).opsize])-1);
-
 {$ifdef x86_64}
                     { Be careful of, for example:
                         movl %reg1,%reg2
@@ -5676,7 +5689,7 @@ unit aoptx86;
                       end;
 {$endif x86_64}
 
-                    taicpu(hp1).changeopsize(taicpu(hp2).opsize);
+                    ChangeArithmeticOpSize(taicpu(hp1),taicpu(hp2).opsize);
                     taicpu(p).changeopsize(taicpu(hp2).opsize);
                     if taicpu(p).oper[0]^.typ=top_reg then
                       setsubreg(taicpu(p).oper[0]^.reg,getsubreg(taicpu(hp2).oper[0]^.reg));
@@ -15126,7 +15139,7 @@ unit aoptx86;
                 decw    %eax            addw    %edx,%eax     hp1
                 movw    %ax,%si         movw    %ax,%si       hp2
             }
-            taicpu(hp1).changeopsize(taicpu(hp2).opsize);
+            ChangeArithmeticOpSize(taicpu(hp1),taicpu(hp2).opsize);
             {
               ->
                 movswl  %si,%eax        movswl  %si,%eax      p

--- a/tests/webtbs/tw41480.pp
+++ b/tests/webtbs/tw41480.pp
@@ -1,0 +1,30 @@
+{ %OPT=-O2 }
+
+program tw41480;
+
+{$mode delphi}
+
+function Convert(I: UInt32): Word;
+var
+  W: Word;
+begin
+  W := 0;
+  if I < $10000 then
+    W := Word(I)
+  else if I < $20000 then
+    W := Word(I - $10000)
+  else if I < $30000 then
+    W := Word(I - $20000);
+  Result := W;
+end;
+
+begin
+  if Convert($0000ffff) <> $ffff then
+    Halt(1);
+  if Convert($00012345) <> $2345 then
+    Halt(2);
+  if Convert($0002ffff) <> $ffff then
+    Halt(3);
+  if Convert($00030000) <> 0 then
+    Halt(4);
+end.


### PR DESCRIPTION
**Problem.** FPC issue [#41480](https://gitlab.com/freepascal.org/fpc/source/-/issues/41480): three peephole folds that narrow an arithmetic instruction to the size of a following `MOV`/`MOVZX` changed the operand size but kept the constant in the wider immediate domain, so under `-O2`/`-O3` the assembler received a value that does not fit the narrowed encoding ("word value exceeds bounds 65536").

**Fix.** Route the three paths in `aoptx86.pas` through `ChangeArithmeticOpSize`, which masks the constant only on an actual narrowing. Equal width, widening and register operands are unchanged.

**Test.** `tests/webtbs/tw41480.pp` (`-O2`): assembler error on current `main`, runs after the fix.

**Validation.** Win64 build of `main` (a359fc19) with the patch; 405 neighbouring tests from `tests/test` (inline, rtti, helpers, generics, opt) give identical results before and after.

:robot: Generated with [Claude Code](https://claude.com/claude-code)