### PR TITLE
helpers: materialize a non-lvalue instance before calling a helper (fixes upstream#41589)

### DIFF
--- a/compiler/pexpr.pas
+++ b/compiler/pexpr.pas
@@ -2507,6 +2507,29 @@ implementation
       end;
 
 
+    procedure materialize_helper_instance(var node:tnode;helperdef:tobjectdef);
+      var
+        n : tnode;
+        newstatement : tstatementnode;
+        temp : ttempcreatenode;
+        extdef : tdef;
+      begin
+        if not((node.nodetype in (nodetype_const+[addrn])) or
+               (nf_no_lvalue in node.flags)) then
+          exit;
+        extdef:=helperdef.extendeddef;
+        newstatement:=nil;
+        n:=internalstatements(newstatement);
+        temp:=ctempcreatenode.create(extdef,extdef.size,tt_persistent,false);
+        addstatement(newstatement,temp);
+        addstatement(newstatement,cassignmentnode.create(ctemprefnode.create(temp),node));
+        addstatement(newstatement,ctempdeletenode.create_normal_temp(temp));
+        addstatement(newstatement,ctemprefnode.create(temp));
+        node:=n;
+        do_typecheckpass(node)
+      end;
+
+
     { the ID token has to be consumed before calling this function }
     procedure do_member_read(structh:tabstractrecorddef;getaddr:boolean;sym:tsym;var p1:tnode;var again:boolean;callflags:tcallnodeflags;spezcontext:tspecializationcontext);
       var
@@ -2529,6 +2552,9 @@ implementation
            end
          else
            begin
+              if assigned(p1) and
+                 is_objectpascal_helper(tdef(sym.owner.defowner)) then
+                materialize_helper_instance(p1,tobjectdef(sym.owner.defowner));
               if assigned(p1) then
                begin
                  if not assigned(p1.resultdef) then
@@ -3225,10 +3251,6 @@ implementation
         var
           srsym : tsym;
           srsymtable : tsymtable;
-          n : tnode;
-          newstatement : tstatementnode;
-          temp : ttempcreatenode;
-          extdef : tdef;
         begin
           result:=false;
           if (current_scanner.token=_ID) and (block_type in [bt_body,bt_general,bt_except,bt_const]) then
@@ -3246,20 +3268,6 @@ implementation
                   if not (srsymtable.symtabletype=objectsymtable) or
                       not is_objectpascal_helper(tdef(srsymtable.defowner)) then
                     internalerror(2013011401);
-                  { convert const node to temp node of the extended type }
-                  if node.nodetype in (nodetype_const+[addrn]) then
-                    begin
-                      extdef:=tobjectdef(srsymtable.defowner).extendeddef;
-                      newstatement:=nil;
-                      n:=internalstatements(newstatement);
-                      temp:=ctempcreatenode.create(extdef,extdef.size,tt_persistent,false);
-                      addstatement(newstatement,temp);
-                      addstatement(newstatement,cassignmentnode.create(ctemprefnode.create(temp),node));
-                      addstatement(newstatement,ctempdeletenode.create_normal_temp(temp));
-                      addstatement(newstatement,ctemprefnode.create(temp));
-                      node:=n;
-                      do_typecheckpass(node)
-                    end;
                   check_hints(srsym,srsym.symoptions,srsym.deprecatedmsg);
                   consume(_ID);
                   do_member_read(nil,getaddr,srsym,node,again,[],nil);

--- a/tests/webtbs/tw41589.pp
+++ b/tests/webtbs/tw41589.pp
@@ -1,0 +1,67 @@
+program tw41589;
+
+{$mode delphi}
+
+type
+  TValue = record
+    A, B: LongInt;
+  end;
+
+  TValueHelper = record helper for TValue
+    procedure SetA(Value: LongInt);
+    function Sum: LongInt;
+  end;
+
+  THolder = class
+  private
+    FByField: TValue;
+    FByGetter: TValue;
+    function GetByGetter: TValue;
+  public
+    property ByField: TValue read FByField write FByField;
+    property ByGetter: TValue read GetByGetter write FByGetter;
+  end;
+
+procedure TValueHelper.SetA(Value: LongInt);
+begin
+  Self.A := Value;
+end;
+
+function TValueHelper.Sum: LongInt;
+begin
+  Result := Self.A + Self.B;
+end;
+
+function THolder.GetByGetter: TValue;
+begin
+  Result := FByGetter;
+end;
+
+var
+  Holder: THolder;
+  V: TValue;
+begin
+  V.A := 100;
+  V.B := 200;
+  V.SetA(11);
+  if (V.A <> 11) or (V.Sum <> 211) then
+    Halt(1);
+
+  Holder := THolder.Create;
+  try
+    V.A := 100;
+    V.B := 200;
+    Holder.ByField := V;
+    Holder.ByGetter := V;
+
+    if (Holder.ByField.Sum <> 300) or (Holder.ByGetter.Sum <> 300) then
+      Halt(2);
+
+    Holder.ByField.SetA(22);
+    Holder.ByGetter.SetA(33);
+    if (Holder.ByField.A <> 100) or (Holder.ByGetter.A <> 100) then
+      Halt(3);
+  finally
+    Holder.Free;
+  end;
+end.


### PR DESCRIPTION
**Problem.** FPC issue [#41589](https://gitlab.com/freepascal.org/fpc/source/-/issues/41589): a record-valued property read is flagged `nf_no_lvalue`, but helper lookup passed the backing field directly as hidden `Self`, so a mutating helper method changed the field behind a property read while the same call on a getter worked on a copy.

**Fix.** In `pexpr.pas` move the existing materialization of constant and address nodes into `materialize_helper_instance`, call it from the common consumer `do_member_read`, and let it accept `nf_no_lvalue` nodes as well: a genuine lvalue keeps its address, a non-lvalue is copied into a temporary with normal cleanup.

**Test.** `tests/webtbs/tw41589.pp`: the backing field is mutated through the property read on current `main` (exit code 3), unchanged after the fix.

**Validation.** Win64 build of `main` (a359fc19) with the patch; 405 neighbouring tests from `tests/test` (inline, rtti, helpers, generics, opt) give identical results before and after.

:robot: Generated with [Claude Code](https://claude.com/claude-code)