### PR TITLE
x86: derive the asm memory width of by-reference formals (fixes upstream#41630)

### DIFF
--- a/compiler/x86/rax86int.pas
+++ b/compiler/x86/rax86int.pas
@@ -1762,6 +1762,7 @@ Unit Rax86int;
         hl : tasmlabel;
         hastypecast: boolean;
         tmpoper: tx86operand;
+        refparasym: tabstractnormalvarsym;
         cse_in_flags: tconstsymbolexpressioninputflags;
         cse_out_flags: tconstsymbolexpressionoutputflags;
       Begin
@@ -1863,7 +1864,27 @@ Unit Rax86int;
                        { convert OPR_LOCAL register para into a reference base }
                        if (oper.opr.typ=OPR_LOCAL) and
                           AsmRegisterPara(oper.opr.localsym) then
-                         oper.InitRefConvertLocal
+                         begin
+                           refparasym:=oper.opr.localsym;
+                           oper.InitRefConvertLocal;
+                           if not oper.hastype then
+                             begin
+                               { The register contains the address, so the
+                                 parameter size is not the referenced data size. }
+                               oper.size:=OS_NO;
+                               oper.opsize:=S_NO;
+                               { A by-reference formal is different: the register
+                                 holds the address of the parameter's own type,
+                                 so a scalar vardef states the dereferenced width
+                                 exactly - "mov [Value],0" on a var UInt64 is a
+                                 qword store.  A value Pointer or an ABI-indirect
+                                 aggregate keeps the width unknown, and an
+                                 explicit "ptr" above stays authoritative. }
+                               if (refparasym.varspez in [vs_var,vs_out,vs_constref]) and
+                                  (refparasym.vardef.typ in [orddef,enumdef,floatdef,pointerdef,classrefdef]) then
+                                 oper.SetSize(refparasym.vardef.size,false);
+                             end;
+                         end
                        else
                          begin
 {$ifdef x86_64}

--- a/tests/webtbs/tw41630.pp
+++ b/tests/webtbs/tw41630.pp
@@ -1,0 +1,16 @@
+{ %norun }
+{ %cpu=x86_64 }
+
+{$mode delphi}
+{$asmmode intel}
+
+procedure LoadStore(Buffer: Pointer); assembler;
+asm
+  movss xmm2, [Buffer]
+  movss [Buffer], xmm2
+  vmovss xmm2, [Buffer]
+  vmovss [Buffer], xmm2
+end;
+
+begin
+end.

--- a/tests/webtbs/tw41630a.pp
+++ b/tests/webtbs/tw41630a.pp
@@ -1,0 +1,133 @@
+{ %cpu=i386,x86_64 }
+{ %OPT=-O2 }
+{$mode objfpc}
+{$asmmode intel}
+
+{ The same bracket syntax must distinguish a pointer value from a var/out/
+  constref scalar. Immediate stores test inferred widths; sentinels catch
+  stores wider than the declared type. Explicit ptr widths take precedence. }
+
+procedure ClearByte(var V: Byte); assembler;
+asm
+  mov [V], 0
+end;
+
+procedure ClearWord(var V: Word); assembler;
+asm
+  mov [V], 0
+end;
+
+procedure ClearDWord(out V: LongWord); assembler;
+asm
+  mov [V], 0
+end;
+
+{$ifdef cpux86_64}
+procedure ClearQWord(var V: QWord); assembler;
+asm
+  mov [V], 0
+end;
+{$endif}
+
+function IsZero(constref V: Word): Boolean; assembler;
+asm
+  cmp [V], 0
+  sete al
+end;
+
+procedure SetLowByte(var V: LongWord); assembler;
+asm
+  mov byte ptr [V], $5a
+end;
+
+procedure SetLowWord(var V: LongWord); assembler;
+asm
+  mov word ptr [V], $abcd
+end;
+
+procedure ClearThroughPointer(V: Pointer); assembler;
+asm
+  mov byte ptr [V], 0
+end;
+
+procedure SetSingle(out V: Single); assembler;
+asm
+  mov [V], $3f800000
+end;
+
+procedure CopySingle(var Dest: Single; constref Src: Single); assembler;
+asm
+  movss xmm0, [Src]
+  movss [Dest], xmm0
+end;
+
+procedure ClearPointer(var V: Pointer); assembler;
+asm
+  mov [V], 0
+end;
+
+type
+  TGuarded = packed record
+    Before: LongWord;
+    Data: QWord;
+    After: LongWord;
+  end;
+var
+  G: TGuarded;
+  F: Single;
+
+procedure Reset;
+begin
+  G.Before := $13579bdf;
+  G.Data := High(QWord);
+  G.After := $2468ace0;
+end;
+
+procedure Check(Expected: QWord);
+begin
+  if (G.Before <> $13579bdf) or (G.After <> $2468ace0) or (G.Data <> Expected) then
+    Halt(1);
+end;
+
+begin
+  Reset;
+  ClearByte(PByte(@G.Data)^);
+  Check(QWord($ffffffffffffff00));
+  Reset;
+  ClearWord(PWord(@G.Data)^);
+  Check(QWord($ffffffffffff0000));
+  if not IsZero(PWord(@G.Data)^) then Halt(2);
+  Reset;
+  if IsZero(PWord(@G.Data)^) then Halt(3);
+  ClearDWord(PLongWord(@G.Data)^);
+  Check(QWord($ffffffff00000000));
+{$ifdef cpux86_64}
+  Reset;
+  ClearQWord(G.Data);
+  Check(0);
+{$endif}
+  Reset;
+  SetLowByte(PLongWord(@G.Data)^);
+  Check(QWord($ffffffffffffff5a));
+  Reset;
+  SetLowWord(PLongWord(@G.Data)^);
+  Check(QWord($ffffffffffffabcd));
+  Reset;
+  ClearThroughPointer(@G.Data);
+  Check(QWord($ffffffffffffff00));
+  Reset;
+  SetSingle(PSingle(@G.Data)^);
+  Check(QWord($ffffffff3f800000));
+  Reset;
+  F := 1.25;
+  CopySingle(PSingle(@G.Data)^, F);
+  Check(QWord($ffffffff3fa00000));
+  Reset;
+  ClearPointer(PPointer(@G.Data)^);
+{$ifdef cpux86_64}
+  Check(0);
+{$else}
+  Check(QWord($ffffffff00000000));
+{$endif}
+  writeln('ok');
+end.

--- a/tests/webtbs/tw41630b.pp
+++ b/tests/webtbs/tw41630b.pp
@@ -1,0 +1,12 @@
+{ %fail }
+{ %cpu=i386,x86_64 }
+{$asmmode intel}
+
+{ The formal's Single type must not silently override an explicit qword. }
+procedure BadWidth(var V: Single); assembler;
+asm
+  movss xmm0, qword ptr [V]
+end;
+
+begin
+end.


### PR DESCRIPTION
**Problem.** [FPC #41630](https://gitlab.com/freepascal.org/fpc/source/-/issues/41630): the inline assembler confused a register parameter's pointer width with the width of the memory it addresses.

**Fix.** Clear that guess for value pointers. Scalar `var/out/constref` parameters use their declared width; explicit `ptr` sizes remain authoritative.

**Tests.** `tw41630` covers pointer SSE/AVX loads and stores without executing AVX. `tw41630a` executes guarded stores and reads for Byte/Word/LongWord/QWord/Single/Pointer through var/out/constref, with inferred and explicitly overridden widths. Sentinels detect overwrites. `tw41630b` verifies that an explicit invalid qword MOVSS operand is rejected.

**Validation.** The runtime matrix passes on this Unleashed branch at -O3 on Win64. In the FPC MR it passes -O-/-O2/-O3 on both x86_64-win64 and i386-win32; the negative test rejects on both. Removing only scalar by-reference inference makes seven size-dependent instructions fail, independently covering that branch.

Upstream MR: https://gitlab.com/freepascal.org/fpc/source/-/merge_requests/1552. This PR waits for the FPC decision.