### PR TITLE
generics: defer the VMT of a partial specialization (fixes upstream#41788)

### DIFF
--- a/compiler/ncgvmt.pas
+++ b/compiler/ncgvmt.pas
@@ -1354,8 +1354,9 @@ implementation
                 do_write_vmts(trecorddef(def).symtable,is_global);
               objectdef :
                 begin
-                  { Skip generics and forward defs }
+                  { Skip generics, partial specializations and forward defs }
                   if ([df_generic,df_genconstraint]*def.defoptions<>[]) or
+                     tstoreddef(def).has_generic_paras or
                      (oo_is_forward in tobjectdef(def).objectoptions) then
                     continue;
                   if tobjectdef(def).is_unique_objpasdef then

--- a/compiler/pgenutil.pas
+++ b/compiler/pgenutil.pas
@@ -1716,18 +1716,6 @@ uses
               end;
           end;
 
-      function has_generic_paras(adef: tstoreddef): boolean;
-        var
-          i: Integer;
-        begin
-          result:=False;
-          if adef.genericparas<>nil then
-            for i:=0 to adef.genericparas.Count-1 do
-              if ((tsym(adef.genericparas[i]).typ=typesym) and (sp_generic_para in tsym(adef.genericparas[i]).symoptions)) or
-                  ((tsym(adef.genericparas[i]).typ=constsym) and not (sp_generic_const in tsym(adef.genericparas[i]).symoptions)) then
-                exit(true);
-        end;
-
       var
         finalspecializename,
         ufinalspecializename : tidstring;
@@ -2263,7 +2251,7 @@ uses
                 tdef(item).ChangeOwner(specializest);
                 { for partial specializations we implicitly declare any methods as having their
                   implementations although we'll not specialize them in reality }
-                if parse_generic or has_generic_paras(tstoreddef(item)) then
+                if parse_generic or tstoreddef(item).has_generic_paras then
                   unset_forwarddef(tdef(item));
               end;
 
@@ -2279,7 +2267,7 @@ uses
 
             { procdefs are only added once we know which overload we use }
             if not parse_generic and (result.typ<>procdef) and
-              not has_generic_paras(tstoreddef(result)) then
+              not tstoreddef(result).has_generic_paras then
                   current_module.pendingspecializations.add(result.typename,result);
           end;
 

--- a/compiler/symdef.pas
+++ b/compiler/symdef.pas
@@ -181,6 +181,9 @@ interface
           function is_generic:boolean;
           { same as above for specializations }
           function is_specialization:boolean;
+          { true if this def still contains generic parameters that require
+            specialization }
+          function has_generic_paras:boolean;
           { generic utilities }
           function is_generic_param_const(index:integer):boolean;inline;
           function get_generic_param_def(index:integer):tdef;inline;
@@ -2759,6 +2762,23 @@ implementation
              end;
            result:=false;
          end;
+     end;
+
+
+   function tstoreddef.has_generic_paras: boolean;
+     var
+       i: longint;
+       sym: tsym;
+     begin
+       result:=false;
+       if assigned(genericparas) then
+         for i:=0 to genericparas.count-1 do
+           begin
+             sym:=tsym(genericparas[i]);
+             if ((sym.typ=symconst.typesym) and (sp_generic_para in sym.symoptions)) or
+                ((sym.typ=symconst.constsym) and not (sp_generic_const in sym.symoptions)) then
+               exit(true);
+           end;
      end;
 
 

--- a/tests/webtbs/tw41788.pp
+++ b/tests/webtbs/tw41788.pp
@@ -1,0 +1,63 @@
+program tw41788;
+
+{$mode delphi}
+
+type
+  TEnumerator<T> = class
+  protected
+    function DoMoveNext: Boolean; virtual;
+  end;
+
+  TEnumerable = class
+    class function List<T>: TEnumerator<T>; static;
+  end;
+
+  TConsumer<T> = class
+    procedure Run;
+  end;
+
+var
+  MoveCount: LongInt;
+  ValueDigest: LongInt;
+
+function TEnumerator<T>.DoMoveNext: Boolean;
+begin
+  Inc(MoveCount);
+  ValueDigest := ValueDigest + 41788;
+  Result := True;
+end;
+
+class function TEnumerable.List<T>: TEnumerator<T>;
+begin
+  Result := TEnumerator<T>.Create;
+end;
+
+procedure TConsumer<T>.Run;
+var
+  Enumerator: TEnumerator<T>;
+begin
+  Enumerator := TEnumerable.List<T>;
+  try
+    if not Enumerator.DoMoveNext then
+      Halt(3);
+  finally
+    Enumerator.Free;
+  end;
+end;
+
+var
+  Consumer: TConsumer<LongInt>;
+begin
+  MoveCount := 0;
+  ValueDigest := 0;
+  Consumer := TConsumer<LongInt>.Create;
+  try
+    Consumer.Run;
+  finally
+    Consumer.Free;
+  end;
+  if MoveCount <> 1 then
+    Halt(1);
+  if ValueDigest <> 41788 then
+    Halt(2);
+end.


### PR DESCRIPTION
**Problem.** FPC issue [#41788](https://gitlab.com/freepascal.org/fpc/source/-/issues/41788): a specialization whose arguments still contain parameters of the enclosing generic has no generated method bodies. Phase 2 already kept such a def out of the pending specializations, but `ncgvmt` still emitted a VMT with references to the missing bodies, so linking failed with an undefined symbol.

**Fix.** Move the unresolved-parameters check from a local helper in `pgenutil.pas` to `tstoreddef.has_generic_paras` and use it in `ncgvmt.pas` as well. The VMT layout is still built to validate overrides in partial descendants; concrete specializations are unchanged.

**Test.** `tests/webtbs/tw41788.pp`: link error on current `main`, runs after the fix.

**Validation.** Win64 build of `main` (a359fc19) with the patch; 405 neighbouring tests from `tests/test` (inline, rtti, helpers, generics, opt) give identical results before and after.

:robot: Generated with [Claude Code](https://claude.com/claude-code)